### PR TITLE
fix: Page equality check in conjunction with mkdocs-section-index

### DIFF
--- a/mkdocs_pagenav_generator/plugin.py
+++ b/mkdocs_pagenav_generator/plugin.py
@@ -10,7 +10,7 @@ class NavGeneratorPlugin(BasePlugin):
     def on_post_page(self, output, page, config):
         if '{nav}' in output:
             children = page.parent.children if page.parent else self.nav.items
-            siblings = [child for child in children if child != page]
+            siblings = [child for child in children if child is not page]
             return output.replace('{nav}', self._format_links(siblings, page, config))
 
     def _format_links(self, items, page, config):


### PR DESCRIPTION
Howdy. We've been using this plugin, but after updating our dependencies, it suddenly stopped working.

It looks like it's our usage of `mkdocs-section-index`, and it's latest 0.3.x release, has stopped the list comprehension from filtering properly. At a guess it's something to do with `SectionPage` versus `Page` objects, but I'm not 100% sure.

Changing the equality operator makes it work for me locally, but if you have any other suggestions, please do advise :) 